### PR TITLE
feat: add `MockBehavior`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
 		<PackageVersion Include="aweXpect.Core" Version="2.23.0"/>
 	</ItemGroup>
 	<ItemGroup>
+		<PackageVersion Include="IsExternalInit" Version="1.0.3" />
 		<PackageVersion Include="Nullable" Version="1.3.1"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Source/aweXpect.Mocks.SourceGenerators/Internals/SourceGeneration.MockClass.cs
+++ b/Source/aweXpect.Mocks.SourceGenerators/Internals/SourceGeneration.MockClass.cs
@@ -106,7 +106,7 @@ internal static partial class SourceGeneration
 		sb.AppendLine("\t}");
 		sb.Append("\tpublic class Mock : Mock<").Append(mockClass.ClassName).AppendLine(">");
 		sb.AppendLine("\t{");
-		sb.AppendLine("\t\tpublic Mock()");
+		sb.AppendLine("\t\tpublic Mock(MockBehavior mockBehavior) : base(mockBehavior)");
 		sb.AppendLine("\t\t{");
 		sb.AppendLine("\t\t\tObject = new MockObject(this);");
 		sb.AppendLine("\t\t}");

--- a/Source/aweXpect.Mocks.SourceGenerators/Internals/SourceGeneration.RegisterMocks.cs
+++ b/Source/aweXpect.Mocks.SourceGenerators/Internals/SourceGeneration.RegisterMocks.cs
@@ -26,7 +26,7 @@ internal static partial class SourceGeneration
 		          {
 		          	private partial class MockGenerator
 		          	{
-		          		partial void Generate<T>()
+		          		partial void Generate<T>(MockBehavior mockBehavior)
 		          		{
 
 		          """;
@@ -45,7 +45,7 @@ internal static partial class SourceGeneration
 			result += $$"""
 			            if (typeof(T) == typeof({{mock.ClassName}}))
 			            			{
-			            				_value = new For{{mock.ClassName}}.Mock() as Mock<T>;
+			            				_value = new For{{mock.ClassName}}.Mock(mockBehavior) as Mock<T>;
 			            			}
 
 			            """;

--- a/Source/aweXpect.Mocks.SourceGenerators/Internals/SourceGeneration.cs
+++ b/Source/aweXpect.Mocks.SourceGenerators/Internals/SourceGeneration.cs
@@ -16,17 +16,24 @@ internal static partial class SourceGeneration
 			public static Mock<T> For<T>()
 			{
 				var generator = new MockGenerator();
-				return generator.Get<T>()
+				return generator.Get<T>(MockBehavior.Default)
+					?? throw new NotSupportedException("Could not generate Mock<T>");
+			}
+			
+			public static Mock<T> For<T>(MockBehavior mockBehavior)
+			{
+				var generator = new MockGenerator();
+				return generator.Get<T>(mockBehavior)
 					?? throw new NotSupportedException("Could not generate Mock<T>");
 			}
 			
 			private partial class MockGenerator
 			{
 				private object? _value;
-				partial void Generate<T>();
-				public Mock<T>? Get<T>()
+				partial void Generate<T>(MockBehavior mockBehavior);
+				public Mock<T>? Get<T>(MockBehavior mockBehavior)
 				{
-					Generate<T>();
+					Generate<T>(mockBehavior);
 					return _value as Mock<T>;
 				}
 			}

--- a/Source/aweXpect.Mocks/Exceptions/MockException.cs
+++ b/Source/aweXpect.Mocks/Exceptions/MockException.cs
@@ -2,12 +2,17 @@
 
 namespace aweXpect.Mocks.Exceptions;
 
+/// <summary>
+///     Represents the base class for exceptions thrown by mock objects during unit testing.
+/// </summary>
 public abstract class MockException : Exception
 {
+	/// <inheritdoc cref="MockException" />
 	protected MockException(string message) : base(message)
 	{
 	}
 
+	/// <inheritdoc cref="MockException" />
 	protected MockException(string message, Exception innerException) : base(message, innerException)
 	{
 	}

--- a/Source/aweXpect.Mocks/Exceptions/MockException.cs
+++ b/Source/aweXpect.Mocks/Exceptions/MockException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace aweXpect.Mocks.Exceptions;
+
+public abstract class MockException : Exception
+{
+	protected MockException(string message) : base(message)
+	{
+	}
+
+	protected MockException(string message, Exception innerException) : base(message, innerException)
+	{
+	}
+}

--- a/Source/aweXpect.Mocks/Exceptions/MockNotSetupException.cs
+++ b/Source/aweXpect.Mocks/Exceptions/MockNotSetupException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace aweXpect.Mocks.Exceptions;
+
+public class MockNotSetupException : MockException
+{
+	public MockNotSetupException(string message) : base(message)
+	{
+	}
+
+	public MockNotSetupException(string message, Exception innerException) : base(message, innerException)
+	{
+	}
+}

--- a/Source/aweXpect.Mocks/Exceptions/MockNotSetupException.cs
+++ b/Source/aweXpect.Mocks/Exceptions/MockNotSetupException.cs
@@ -2,12 +2,17 @@
 
 namespace aweXpect.Mocks.Exceptions;
 
+/// <summary>
+/// Represents an exception that is thrown when a mock object is used without being properly set up.
+/// </summary>
 public class MockNotSetupException : MockException
 {
+	/// <inheritdoc cref="MockNotSetupException" />
 	public MockNotSetupException(string message) : base(message)
 	{
 	}
 
+	/// <inheritdoc cref="MockNotSetupException" />
 	public MockNotSetupException(string message, Exception innerException) : base(message, innerException)
 	{
 	}

--- a/Source/aweXpect.Mocks/MockBehavior.cs
+++ b/Source/aweXpect.Mocks/MockBehavior.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace aweXpect.Mocks;
+
+/// <summary>
+/// The behavior of the mock.
+/// </summary>
+public record MockBehavior
+{
+	/// <summary>
+	/// Specifies whether an exception is thrown when an operation is attempted without prior setup.
+	/// </summary>
+	public bool ThrowWhenNotSetup { get; init; } = true;
+
+	/// <summary>
+	/// Specifies the strategy used to determine how default values that are not prior setup are generated.
+	/// </summary>
+	public IDefaultValueGenerator DefaultValueGenerator { get; init; } = new ReturnDefaultDefaultValueGenerator();
+
+	private static MockBehavior _globalDefault = new MockBehavior();
+
+	/// <summary>
+	///     The globally used default behavior settings.
+	/// </summary>
+	public static MockBehavior Default => _globalDefault;
+
+	/// <summary>
+	/// Defines a mechanism for generating default values of a specified type.
+	/// </summary>
+	public interface IDefaultValueGenerator
+	{
+		/// <summary>
+		/// Generates a default value of the specified type.
+		/// </summary>
+		T Generate<T>();
+	}
+
+	private class ReturnDefaultDefaultValueGenerator : IDefaultValueGenerator
+	{
+		private static (Type Type, object Value)[] _defaultValues =
+			[
+				(typeof(Task), Task.CompletedTask),
+				(typeof(CancellationToken), CancellationToken.None),
+			];
+
+		/// <inheritdoc cref="IDefaultValueGenerator.Generate{T}" />
+		public T Generate<T>()
+		{
+			foreach (var defaultValue in _defaultValues)
+			{
+				if (defaultValue.Value is T value &&
+					defaultValue.Type == typeof(T))
+				{
+					return value;
+				}
+			}
+
+			return default!;
+		}
+	}
+}

--- a/Source/aweXpect.Mocks/MockBehavior.cs
+++ b/Source/aweXpect.Mocks/MockBehavior.cs
@@ -37,9 +37,9 @@ public record MockBehavior
 		T Generate<T>();
 	}
 
-	private class ReturnDefaultDefaultValueGenerator : IDefaultValueGenerator
+	private sealed class ReturnDefaultDefaultValueGenerator : IDefaultValueGenerator
 	{
-		private static (Type Type, object Value)[] _defaultValues =
+		private static readonly (Type Type, object Value)[] _defaultValues =
 			[
 				(typeof(Task), Task.CompletedTask),
 				(typeof(CancellationToken), CancellationToken.None),

--- a/Source/aweXpect.Mocks/Setup/IMockSetup.cs
+++ b/Source/aweXpect.Mocks/Setup/IMockSetup.cs
@@ -6,6 +6,11 @@ namespace aweXpect.Mocks.Setup;
 public interface IMockSetup
 {
 	/// <summary>
+	/// Gets the behavior settings used by this mock instance.
+	/// </summary>
+	MockBehavior Behavior { get; }
+
+	/// <summary>
 	///     Registers the <paramref name="methodSetup" /> in the mock.
 	/// </summary>
 	void RegisterMethod(MethodSetup methodSetup);

--- a/Source/aweXpect.Mocks/Setup/MockSetup.cs
+++ b/Source/aweXpect.Mocks/Setup/MockSetup.cs
@@ -5,6 +5,10 @@
 /// </summary>
 public class MockSetup<T>(Mock<T> mock) : IMockSetup
 {
+	/// <inheritdoc cref="IMockSetup.Behavior" />
+	MockBehavior IMockSetup.Behavior
+		=> ((IMockSetup)mock).Behavior;
+
 	/// <inheritdoc cref="IMockSetup.RegisterMethod" />
 	void IMockSetup.RegisterMethod(MethodSetup methodSetup)
 		=> ((IMockSetup)mock).RegisterMethod(methodSetup);

--- a/Source/aweXpect.Mocks/aweXpect.Mocks.csproj
+++ b/Source/aweXpect.Mocks/aweXpect.Mocks.csproj
@@ -5,7 +5,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="$(MSBuildProjectDirectory)\..\aweXpect.Mocks.SourceGenerators\bin\$(Configuration)\netstandard2.0\aweXpect.Mocks.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+		<None Include="$(MSBuildProjectDirectory)\..\aweXpect.Mocks.SourceGenerators\bin\$(Configuration)\netstandard2.0\aweXpect.Mocks.SourceGenerators.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="aweXpect.Core" />
+		<PackageReference Include="IsExternalInit">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 </Project>

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net10.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net10.0.txt
@@ -1,5 +1,18 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Mocks.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace aweXpect.Mocks.Exceptions
+{
+    public abstract class MockException : System.Exception
+    {
+        protected MockException(string message) { }
+        protected MockException(string message, System.Exception innerException) { }
+    }
+    public class MockNotSetupException : aweXpect.Mocks.Exceptions.MockException
+    {
+        public MockNotSetupException(string message) { }
+        public MockNotSetupException(string message, System.Exception innerException) { }
+    }
+}
 namespace aweXpect.Mocks.Invocations
 {
     public class Invocation
@@ -26,9 +39,21 @@ namespace aweXpect.Mocks.Invocations
 }
 namespace aweXpect.Mocks
 {
+    public class MockBehavior : System.IEquatable<aweXpect.Mocks.MockBehavior>
+    {
+        public MockBehavior() { }
+        public aweXpect.Mocks.MockBehavior.IDefaultValueGenerator DefaultValueGenerator { get; init; }
+        public bool ThrowWhenNotSetup { get; init; }
+        public static aweXpect.Mocks.MockBehavior Default { get; }
+        public interface IDefaultValueGenerator
+        {
+            T Generate<T>();
+        }
+    }
     public abstract class Mock<T> : aweXpect.Mocks.Setup.IMockSetup
     {
-        protected Mock() { }
+        protected Mock(aweXpect.Mocks.MockBehavior mockBehavior) { }
+        public aweXpect.Mocks.MockBehavior Behavior { get; }
         public System.Collections.Generic.IReadOnlyList<aweXpect.Mocks.Invocations.Invocation> Invocations { get; }
         public abstract T Object { get; }
         public aweXpect.Mocks.Setup.MockSetup<T> Setup { get; }
@@ -59,6 +84,7 @@ namespace aweXpect.Mocks.Setup
 {
     public interface IMockSetup
     {
+        aweXpect.Mocks.MockBehavior Behavior { get; }
         void Execute(string methodName, params object?[] parameters);
         TResult Execute<TResult>(string methodName, params object?[] parameters);
         TResult Get<TResult>(string propertyName);

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net8.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net8.0.txt
@@ -1,5 +1,18 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Mocks.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace aweXpect.Mocks.Exceptions
+{
+    public abstract class MockException : System.Exception
+    {
+        protected MockException(string message) { }
+        protected MockException(string message, System.Exception innerException) { }
+    }
+    public class MockNotSetupException : aweXpect.Mocks.Exceptions.MockException
+    {
+        public MockNotSetupException(string message) { }
+        public MockNotSetupException(string message, System.Exception innerException) { }
+    }
+}
 namespace aweXpect.Mocks.Invocations
 {
     public class Invocation
@@ -26,9 +39,21 @@ namespace aweXpect.Mocks.Invocations
 }
 namespace aweXpect.Mocks
 {
+    public class MockBehavior : System.IEquatable<aweXpect.Mocks.MockBehavior>
+    {
+        public MockBehavior() { }
+        public aweXpect.Mocks.MockBehavior.IDefaultValueGenerator DefaultValueGenerator { get; init; }
+        public bool ThrowWhenNotSetup { get; init; }
+        public static aweXpect.Mocks.MockBehavior Default { get; }
+        public interface IDefaultValueGenerator
+        {
+            T Generate<T>();
+        }
+    }
     public abstract class Mock<T> : aweXpect.Mocks.Setup.IMockSetup
     {
-        protected Mock() { }
+        protected Mock(aweXpect.Mocks.MockBehavior mockBehavior) { }
+        public aweXpect.Mocks.MockBehavior Behavior { get; }
         public System.Collections.Generic.IReadOnlyList<aweXpect.Mocks.Invocations.Invocation> Invocations { get; }
         public abstract T Object { get; }
         public aweXpect.Mocks.Setup.MockSetup<T> Setup { get; }
@@ -59,6 +84,7 @@ namespace aweXpect.Mocks.Setup
 {
     public interface IMockSetup
     {
+        aweXpect.Mocks.MockBehavior Behavior { get; }
         void Execute(string methodName, params object?[] parameters);
         TResult Execute<TResult>(string methodName, params object?[] parameters);
         TResult Get<TResult>(string propertyName);

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_netstandard2.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_netstandard2.0.txt
@@ -1,5 +1,18 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Mocks.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+namespace aweXpect.Mocks.Exceptions
+{
+    public abstract class MockException : System.Exception
+    {
+        protected MockException(string message) { }
+        protected MockException(string message, System.Exception innerException) { }
+    }
+    public class MockNotSetupException : aweXpect.Mocks.Exceptions.MockException
+    {
+        public MockNotSetupException(string message) { }
+        public MockNotSetupException(string message, System.Exception innerException) { }
+    }
+}
 namespace aweXpect.Mocks.Invocations
 {
     public class Invocation
@@ -26,9 +39,21 @@ namespace aweXpect.Mocks.Invocations
 }
 namespace aweXpect.Mocks
 {
+    public class MockBehavior : System.IEquatable<aweXpect.Mocks.MockBehavior>
+    {
+        public MockBehavior() { }
+        public aweXpect.Mocks.MockBehavior.IDefaultValueGenerator DefaultValueGenerator { get; init; }
+        public bool ThrowWhenNotSetup { get; init; }
+        public static aweXpect.Mocks.MockBehavior Default { get; }
+        public interface IDefaultValueGenerator
+        {
+            T Generate<T>();
+        }
+    }
     public abstract class Mock<T> : aweXpect.Mocks.Setup.IMockSetup
     {
-        protected Mock() { }
+        protected Mock(aweXpect.Mocks.MockBehavior mockBehavior) { }
+        public aweXpect.Mocks.MockBehavior Behavior { get; }
         public System.Collections.Generic.IReadOnlyList<aweXpect.Mocks.Invocations.Invocation> Invocations { get; }
         public abstract T Object { get; }
         public aweXpect.Mocks.Setup.MockSetup<T> Setup { get; }
@@ -59,6 +84,7 @@ namespace aweXpect.Mocks.Setup
 {
     public interface IMockSetup
     {
+        aweXpect.Mocks.MockBehavior Behavior { get; }
         void Execute(string methodName, params object?[] parameters);
         TResult Execute<TResult>(string methodName, params object?[] parameters);
         TResult Get<TResult>(string propertyName);

--- a/Tests/aweXpect.Mocks.Tests/Dummy/DummyTests.cs
+++ b/Tests/aweXpect.Mocks.Tests/Dummy/DummyTests.cs
@@ -10,7 +10,8 @@ public sealed class DummyTests
 		Mock<IUserService> mock2 = Mock.For<IUserService>();
 		Mock<MyUserRepository> mock3 = Mock.For<MyUserRepository>();
 		mock3.Setup.RemoveUser("foo").Callback(() => isCalled = true).Returns(true);
-		
+		mock3.Setup.RemoveUser(With.Any<string>()).Returns(false);
+
 		mock3.Setup.Values
 			.InitializeWith([1, 2,])
 			.OnGet(() => { isCalled = true; })

--- a/Tests/aweXpect.Mocks.Tests/MockBehaviorTests.cs
+++ b/Tests/aweXpect.Mocks.Tests/MockBehaviorTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Threading;
+
+namespace aweXpect.Mocks.Tests;
+
+public class MockBehaviorTests
+{
+	[Fact]
+	public async Task DefaultValueGenerator_WithInt_ShouldReturnZero()
+	{
+		var sut = new MockBehavior();
+
+		var result = sut.DefaultValueGenerator.Generate<int>();
+
+		await That(result).IsEqualTo(0);
+	}
+
+	[Fact]
+	public async Task DefaultValueGenerator_WithString_ShouldReturnNull()
+	{
+		var sut = new MockBehavior();
+
+		var result = sut.DefaultValueGenerator.Generate<string>();
+
+		await That(result).IsNull();
+	}
+
+	[Fact]
+	public async Task DefaultValueGenerator_WithStruct_ShouldReturnDefault()
+	{
+		var sut = new MockBehavior();
+
+		var result = sut.DefaultValueGenerator.Generate<DateTime>();
+
+		await That(result).IsEqualTo(DateTime.MinValue);
+	}
+
+	[Fact]
+	public async Task DefaultValueGenerator_WithObject_ShouldReturnNull()
+	{
+		var sut = new MockBehavior();
+
+		var result = sut.DefaultValueGenerator.Generate<object>();
+
+		await That(result).IsNull();
+	}
+
+	[Fact]
+	public async Task DefaultValueGenerator_WithNullableInt_ShouldReturnNull()
+	{
+		var sut = new MockBehavior();
+
+		var result = sut.DefaultValueGenerator.Generate<int?>();
+
+		await That(result).IsNull();
+	}
+
+	[Fact]
+	public async Task DefaultValueGenerator_WithCancellationToken_ShouldReturnNone()
+	{
+		var sut = new MockBehavior();
+
+		var result = sut.DefaultValueGenerator.Generate<CancellationToken>();
+
+		await That(result).IsEqualTo(CancellationToken.None);
+	}
+
+	[Fact]
+	public async Task DefaultValueGenerator_WithTask_ShouldReturnCompletedTask()
+	{
+		var sut = new MockBehavior();
+
+		var result = sut.DefaultValueGenerator.Generate<Task>();
+
+		await That(result).IsNotNull();
+		await That(result.IsCompleted).IsTrue();
+		await That(result.IsFaulted).IsFalse();
+	}
+}

--- a/Tests/aweXpect.Mocks.Tests/MockTests.cs
+++ b/Tests/aweXpect.Mocks.Tests/MockTests.cs
@@ -54,6 +54,7 @@ public class MockTests
 	{
 		MyMock<string> sut = new("foo");
 		IMockSetup mockSetup = sut;
+		mockSetup.RegisterMethod(new MethodWithReturnValueSetup<int>("my-method").Returns(0));
 
 		int value = mockSetup.Execute<int>("my-method");
 		mockSetup.Get<int>("my-get-property");
@@ -165,7 +166,7 @@ public class MockTests
 		await That(value).IsEqualTo("foo");
 	}
 
-	private class MyMock<T>(T @object) : Mock<T>
+	private class MyMock<T>(T @object) : Mock<T>(MockBehavior.Default)
 	{
 		public override T Object => @object;
 	}


### PR DESCRIPTION
This PR introduces a `MockBehavior` system to the aweXpect.Mocks library, allowing users to configure how mocks behave when operations are attempted without prior setup. The key enhancement is the ability to either throw exceptions or return default values based on the configured behavior.

### Key changes:
- Adds `MockBehavior` class with configurable settings for exception throwing and default value generation
- Updates `Mock<T>` base class to require and use `MockBehavior` in constructor
- Implements exception handling with new `MockException` hierarchy for better error reporting