### PR TITLE
feat: use behavior for the return value of methods

### DIFF
--- a/Source/aweXpect.Mocks/Mock.cs
+++ b/Source/aweXpect.Mocks/Mock.cs
@@ -23,12 +23,12 @@ public abstract class Mock<T> : IMockSetup
 	private readonly List<Invocation> _invocations = [];
 	private readonly Dictionary<string, PropertySetup> _propertySetups = [];
 	private readonly List<MethodSetup> _setups = [];
+	private readonly MockBehavior _behavior;
 
 	/// <summary>
 	/// Gets the behavior settings used by this mock instance.
 	/// </summary>
 	MockBehavior IMockSetup.Behavior => _behavior;
-	private readonly MockBehavior _behavior;
 
 	/// <summary>
 	///     The registered invocations of the mock.
@@ -45,7 +45,7 @@ public abstract class Mock<T> : IMockSetup
 	/// </summary>
 	public MockSetup<T> Setup => new(this);
 
-	/// <inheritdoc cref="IMockSetup.RegisterMethod" />
+	/// <inheritdoc cref="IMockSetup.RegisterMethod(MethodSetup)" />
 	void IMockSetup.RegisterMethod(MethodSetup methodSetup)
 	{
 		if (_invocations.Count > 0)
@@ -56,7 +56,7 @@ public abstract class Mock<T> : IMockSetup
 		_setups.Add(methodSetup);
 	}
 
-	/// <inheritdoc cref="IMockSetup.RegisterProperty" />
+	/// <inheritdoc cref="IMockSetup.RegisterProperty(string, PropertySetup)" />
 	void IMockSetup.RegisterProperty(string propertyName, PropertySetup propertySetup)
 	{
 		if (_invocations.Count > 0)
@@ -67,9 +67,7 @@ public abstract class Mock<T> : IMockSetup
 		_propertySetups.Add(propertyName, propertySetup);
 	}
 
-	/// <summary>
-	///     Executes a method and gets the setup return value.
-	/// </summary>
+	/// <inheritdoc cref="IMockSetup.Execute{TResult}(string, object?[])" />
 	TResult IMockSetup.Execute<TResult>(string methodName, params object?[] parameters)
 	{
 		Invocation invocation = RegisterInvocation(new MethodInvocation(methodName, parameters));
@@ -85,12 +83,10 @@ public abstract class Mock<T> : IMockSetup
 			return _behavior.DefaultValueGenerator.Generate<TResult>();
 		}
 
-		return matchingSetup.Invoke<TResult>(invocation);
+		return matchingSetup.Invoke<TResult>(invocation, _behavior);
 	}
 
-	/// <summary>
-	///     Executes a method returning <see langword="void" />.
-	/// </summary>
+	/// <inheritdoc cref="IMockSetup.Execute(string, object?[])" />
 	void IMockSetup.Execute(string methodName, params object?[] parameters)
 	{
 		Invocation invocation = RegisterInvocation(new MethodInvocation(methodName, parameters));
@@ -99,9 +95,7 @@ public abstract class Mock<T> : IMockSetup
 		matchingSetup?.Invoke(invocation);
 	}
 
-	/// <summary>
-	///     Executes a method returning <see langword="void" />.
-	/// </summary>
+	/// <inheritdoc cref="IMockSetup.Set(string, object?)" />
 	void IMockSetup.Set(string propertyName, object? value)
 	{
 		Invocation invocation = RegisterInvocation(new PropertySetterInvocation(propertyName, value));
@@ -115,9 +109,7 @@ public abstract class Mock<T> : IMockSetup
 		matchingSetup.InvokeSetter(invocation, value);
 	}
 
-	/// <summary>
-	///     Executes a method and gets the setup return value.
-	/// </summary>
+	/// <inheritdoc cref="IMockSetup.Get{TResult}(string)" />
 	TResult IMockSetup.Get<TResult>(string propertyName)
 	{
 		Invocation invocation = RegisterInvocation(new PropertyGetterInvocation(propertyName));

--- a/Source/aweXpect.Mocks/MockBehavior.cs
+++ b/Source/aweXpect.Mocks/MockBehavior.cs
@@ -10,21 +10,28 @@ namespace aweXpect.Mocks;
 public record MockBehavior
 {
 	/// <summary>
-	/// Specifies whether an exception is thrown when an operation is attempted without prior setup.
+	///     The default mock behavior settings.
 	/// </summary>
-	public bool ThrowWhenNotSetup { get; init; } = true;
+	public static MockBehavior Default => _globalDefault;
 
 	/// <summary>
-	/// Specifies the strategy used to determine how default values that are not prior setup are generated.
+	/// Specifies whether an exception is thrown when an operation is attempted without prior setup.
 	/// </summary>
+	/// <remarks>If set to <see langword="false"/>, the value from the <see cref="DefaultValueGenerator"/> is used for return values of methods or properties.</remarks>
+	public bool ThrowWhenNotSetup { get; init; }
+
+	/// <summary>
+	/// The generator for default values when not specified by a setup.
+	/// </summary>
+	/// <remarks>
+	/// If <see cref="ThrowWhenNotSetup"/> is not set to <see langword="false" />, an exception is thrown in such cases.<para/>
+	/// The default implementation has a fixed set of objects with a not-<see langword="null" /> value:<br />
+	/// - <see cref="Task"/><br />
+	/// - <see cref="CancellationToken"/>
+	/// </remarks>
 	public IDefaultValueGenerator DefaultValueGenerator { get; init; } = new ReturnDefaultDefaultValueGenerator();
 
 	private static MockBehavior _globalDefault = new MockBehavior();
-
-	/// <summary>
-	///     The globally used default behavior settings.
-	/// </summary>
-	public static MockBehavior Default => _globalDefault;
 
 	/// <summary>
 	/// Defines a mechanism for generating default values of a specified type.

--- a/Source/aweXpect.Mocks/Setup/MethodSetup.cs
+++ b/Source/aweXpect.Mocks/Setup/MethodSetup.cs
@@ -13,11 +13,11 @@ public abstract class MethodSetup : IMethodSetup
 	/// <inheritdoc cref="IMethodSetup.InvocationCount" />
 	int IMethodSetup.InvocationCount => _invocationCount;
 
-	internal TResult Invoke<TResult>(Invocation invocation)
+	internal TResult Invoke<TResult>(Invocation invocation, MockBehavior behavior)
 	{
 		Interlocked.Increment(ref _invocationCount);
 		ExecuteCallback(invocation);
-		return GetReturnValue<TResult>(invocation);
+		return GetReturnValue<TResult>(invocation, behavior);
 	}
 
 	internal void Invoke(Invocation invocation)
@@ -34,7 +34,7 @@ public abstract class MethodSetup : IMethodSetup
 	/// <summary>
 	///     Gets the registered return value.
 	/// </summary>
-	protected abstract TResult GetReturnValue<TResult>(Invocation invocation);
+	protected abstract TResult GetReturnValue<TResult>(Invocation invocation, MockBehavior behavior);
 
 	/// <inheritdoc cref="IMethodSetup.Matches(Invocation)" />
 	bool IMethodSetup.Matches(Invocation invocation)

--- a/Source/aweXpect.Mocks/Setup/MethodWithReturnValueSetup.cs
+++ b/Source/aweXpect.Mocks/Setup/MethodWithReturnValueSetup.cs
@@ -41,13 +41,13 @@ public class MethodWithReturnValueSetup<TReturn>(string name) : MethodSetup
 	/// <inheritdoc cref="MethodSetup.ExecuteCallback(Invocation)" />
 	protected override void ExecuteCallback(Invocation invocation) => _callback?.Invoke();
 
-	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation)" />
-	protected override TResult GetReturnValue<TResult>(Invocation invocation)
+	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation, MockBehavior)" />
+	protected override TResult GetReturnValue<TResult>(Invocation invocation, MockBehavior behavior)
 		where TResult : default
 	{
 		if (_returnCallback is null)
 		{
-			throw new NotSupportedException("No return value is specified");
+			return behavior.DefaultValueGenerator.Generate<TResult>();
 		}
 
 		if (_returnCallback() is TResult result)
@@ -127,13 +127,13 @@ public class MethodWithReturnValueSetup<TReturn, T>(string name, With.Parameter 
 		}
 	}
 
-	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation)" />
-	protected override TResult GetReturnValue<TResult>(Invocation invocation)
+	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation, MockBehavior)" />
+	protected override TResult GetReturnValue<TResult>(Invocation invocation, MockBehavior behavior)
 		where TResult : default
 	{
 		if (_returnCallback is null)
 		{
-			throw new NotSupportedException("No return value is specified");
+			return behavior.DefaultValueGenerator.Generate<TResult>();
 		}
 
 		if (invocation is MethodInvocation methodInvocation && methodInvocation.Parameters[0] is T p1 &&

--- a/Source/aweXpect.Mocks/Setup/MethodWithoutReturnValueSetup.cs
+++ b/Source/aweXpect.Mocks/Setup/MethodWithoutReturnValueSetup.cs
@@ -22,8 +22,8 @@ public class MethodWithoutReturnValueSetup(string name) : MethodSetup
 	/// <inheritdoc cref="MethodSetup.ExecuteCallback(Invocation)" />
 	protected override void ExecuteCallback(Invocation invocation) => _callback?.Invoke();
 
-	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation)" />
-	protected override TResult GetReturnValue<TResult>(Invocation invocation)
+	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation, MockBehavior)" />
+	protected override TResult GetReturnValue<TResult>(Invocation invocation, MockBehavior behavior)
 		where TResult : default
 		=> throw new NotSupportedException("The setup does not support return values");
 
@@ -34,16 +34,16 @@ public class MethodWithoutReturnValueSetup(string name) : MethodSetup
 }
 
 /// <summary>
-///     Setup for a method with one parameter <typeparamref name="T" /> returning <see langword="void" />.
+///     Setup for a method with one parameter <typeparamref name="T1" /> returning <see langword="void" />.
 /// </summary>
-public class MethodWithoutReturnValueSetup<T>(string name, With.Parameter match) : MethodSetup
+public class MethodWithoutReturnValueSetup<T1>(string name, With.Parameter match) : MethodSetup
 {
-	private Action<T>? _callback;
+	private Action<T1>? _callback;
 
 	/// <summary>
 	///     Registers a <paramref name="callback" /> to execute when the method is called.
 	/// </summary>
-	public MethodWithoutReturnValueSetup<T> Callback(Action callback)
+	public MethodWithoutReturnValueSetup<T1> Callback(Action callback)
 	{
 		_callback = _ => callback();
 		return this;
@@ -52,7 +52,7 @@ public class MethodWithoutReturnValueSetup<T>(string name, With.Parameter match)
 	/// <summary>
 	///     Registers a <paramref name="callback" /> to execute when the method is called.
 	/// </summary>
-	public MethodWithoutReturnValueSetup<T> Callback(Action<T> callback)
+	public MethodWithoutReturnValueSetup<T1> Callback(Action<T1> callback)
 	{
 		_callback = callback;
 		return this;
@@ -61,14 +61,14 @@ public class MethodWithoutReturnValueSetup<T>(string name, With.Parameter match)
 	/// <inheritdoc cref="MethodSetup.ExecuteCallback(Invocation)" />
 	protected override void ExecuteCallback(Invocation invocation)
 	{
-		if (invocation is MethodInvocation methodInvocation && methodInvocation.Parameters[0] is T p1)
+		if (invocation is MethodInvocation methodInvocation && methodInvocation.Parameters[0] is T1 p1)
 		{
 			_callback?.Invoke(p1);
 		}
 	}
 
-	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation)" />
-	protected override TResult GetReturnValue<TResult>(Invocation invocation)
+	/// <inheritdoc cref="MethodSetup.GetReturnValue{TResult}(Invocation, MockBehavior)" />
+	protected override TResult GetReturnValue<TResult>(Invocation invocation, MockBehavior behavior)
 		where TResult : default
 		=> throw new NotSupportedException("The setup does not support return values");
 

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net10.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net10.0.txt
@@ -133,11 +133,11 @@ namespace aweXpect.Mocks.Setup
         protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
-    public class MethodWithoutReturnValueSetup<T> : aweXpect.Mocks.Setup.MethodSetup
+    public class MethodWithoutReturnValueSetup<T1> : aweXpect.Mocks.Setup.MethodSetup
     {
         public MethodWithoutReturnValueSetup(string name, aweXpect.Mocks.With.Parameter match) { }
-        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T> Callback(System.Action callback) { }
-        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T> Callback(System.Action<T> callback) { }
+        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action callback) { }
+        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action<T1> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net10.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net10.0.txt
@@ -100,7 +100,7 @@ namespace aweXpect.Mocks.Setup
     {
         protected MethodSetup() { }
         protected abstract void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation);
-        protected abstract TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation);
+        protected abstract TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior);
         protected abstract bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation);
     }
     public class MethodWithReturnValueSetup<TReturn> : aweXpect.Mocks.Setup.MethodSetup
@@ -108,7 +108,7 @@ namespace aweXpect.Mocks.Setup
         public MethodWithReturnValueSetup(string name) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Callback(System.Action callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Returns(System.Func<TReturn> callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Returns(TReturn returnValue) { }
@@ -119,7 +119,7 @@ namespace aweXpect.Mocks.Setup
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Callback(System.Action callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Callback(System.Action<T> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Returns(System.Func<TReturn> callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Returns(System.Func<T, TReturn> callback) { }
@@ -130,7 +130,7 @@ namespace aweXpect.Mocks.Setup
         public MethodWithoutReturnValueSetup(string name) { }
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup Callback(System.Action callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
     public class MethodWithoutReturnValueSetup<T1> : aweXpect.Mocks.Setup.MethodSetup
@@ -139,7 +139,7 @@ namespace aweXpect.Mocks.Setup
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action callback) { }
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action<T1> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
     public class MockSetup<T> : aweXpect.Mocks.Setup.IMockSetup

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net8.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net8.0.txt
@@ -133,11 +133,11 @@ namespace aweXpect.Mocks.Setup
         protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
-    public class MethodWithoutReturnValueSetup<T> : aweXpect.Mocks.Setup.MethodSetup
+    public class MethodWithoutReturnValueSetup<T1> : aweXpect.Mocks.Setup.MethodSetup
     {
         public MethodWithoutReturnValueSetup(string name, aweXpect.Mocks.With.Parameter match) { }
-        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T> Callback(System.Action callback) { }
-        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T> Callback(System.Action<T> callback) { }
+        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action callback) { }
+        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action<T1> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net8.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_net8.0.txt
@@ -100,7 +100,7 @@ namespace aweXpect.Mocks.Setup
     {
         protected MethodSetup() { }
         protected abstract void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation);
-        protected abstract TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation);
+        protected abstract TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior);
         protected abstract bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation);
     }
     public class MethodWithReturnValueSetup<TReturn> : aweXpect.Mocks.Setup.MethodSetup
@@ -108,7 +108,7 @@ namespace aweXpect.Mocks.Setup
         public MethodWithReturnValueSetup(string name) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Callback(System.Action callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Returns(System.Func<TReturn> callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Returns(TReturn returnValue) { }
@@ -119,7 +119,7 @@ namespace aweXpect.Mocks.Setup
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Callback(System.Action callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Callback(System.Action<T> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Returns(System.Func<TReturn> callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Returns(System.Func<T, TReturn> callback) { }
@@ -130,7 +130,7 @@ namespace aweXpect.Mocks.Setup
         public MethodWithoutReturnValueSetup(string name) { }
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup Callback(System.Action callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
     public class MethodWithoutReturnValueSetup<T1> : aweXpect.Mocks.Setup.MethodSetup
@@ -139,7 +139,7 @@ namespace aweXpect.Mocks.Setup
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action callback) { }
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action<T1> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
     public class MockSetup<T> : aweXpect.Mocks.Setup.IMockSetup

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_netstandard2.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_netstandard2.0.txt
@@ -133,11 +133,11 @@ namespace aweXpect.Mocks.Setup
         protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
-    public class MethodWithoutReturnValueSetup<T> : aweXpect.Mocks.Setup.MethodSetup
+    public class MethodWithoutReturnValueSetup<T1> : aweXpect.Mocks.Setup.MethodSetup
     {
         public MethodWithoutReturnValueSetup(string name, aweXpect.Mocks.With.Parameter match) { }
-        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T> Callback(System.Action callback) { }
-        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T> Callback(System.Action<T> callback) { }
+        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action callback) { }
+        public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action<T1> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }

--- a/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_netstandard2.0.txt
+++ b/Tests/aweXpect.Mocks.Api.Tests/Expected/aweXpect.Mocks_netstandard2.0.txt
@@ -100,7 +100,7 @@ namespace aweXpect.Mocks.Setup
     {
         protected MethodSetup() { }
         protected abstract void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation);
-        protected abstract TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation);
+        protected abstract TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior);
         protected abstract bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation);
     }
     public class MethodWithReturnValueSetup<TReturn> : aweXpect.Mocks.Setup.MethodSetup
@@ -108,7 +108,7 @@ namespace aweXpect.Mocks.Setup
         public MethodWithReturnValueSetup(string name) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Callback(System.Action callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Returns(System.Func<TReturn> callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn> Returns(TReturn returnValue) { }
@@ -119,7 +119,7 @@ namespace aweXpect.Mocks.Setup
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Callback(System.Action callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Callback(System.Action<T> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Returns(System.Func<TReturn> callback) { }
         public aweXpect.Mocks.Setup.MethodWithReturnValueSetup<TReturn, T> Returns(System.Func<T, TReturn> callback) { }
@@ -130,7 +130,7 @@ namespace aweXpect.Mocks.Setup
         public MethodWithoutReturnValueSetup(string name) { }
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup Callback(System.Action callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
     public class MethodWithoutReturnValueSetup<T1> : aweXpect.Mocks.Setup.MethodSetup
@@ -139,7 +139,7 @@ namespace aweXpect.Mocks.Setup
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action callback) { }
         public aweXpect.Mocks.Setup.MethodWithoutReturnValueSetup<T1> Callback(System.Action<T1> callback) { }
         protected override void ExecuteCallback(aweXpect.Mocks.Invocations.Invocation invocation) { }
-        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation) { }
+        protected override TResult GetReturnValue<TResult>(aweXpect.Mocks.Invocations.Invocation invocation, aweXpect.Mocks.MockBehavior behavior) { }
         protected override bool IsMatch(aweXpect.Mocks.Invocations.Invocation invocation) { }
     }
     public class MockSetup<T> : aweXpect.Mocks.Setup.IMockSetup

--- a/Tests/aweXpect.Mocks.Tests/MockTests.cs
+++ b/Tests/aweXpect.Mocks.Tests/MockTests.cs
@@ -1,5 +1,6 @@
 ﻿using aweXpect.Mocks.Invocations;
 using aweXpect.Mocks.Setup;
+using aweXpect.Mocks.Tests.TestHelpers;
 
 namespace aweXpect.Mocks.Tests;
 
@@ -164,10 +165,5 @@ public class MockTests
 		string value = sut;
 
 		await That(value).IsEqualTo("foo");
-	}
-
-	private class MyMock<T>(T @object) : Mock<T>(MockBehavior.Default)
-	{
-		public override T Object => @object;
 	}
 }

--- a/Tests/aweXpect.Mocks.Tests/Setup/MethodWithReturnValueSetupTests.cs
+++ b/Tests/aweXpect.Mocks.Tests/Setup/MethodWithReturnValueSetupTests.cs
@@ -1,0 +1,122 @@
+﻿using aweXpect.Mocks.Setup;
+using aweXpect.Mocks.Tests.TestHelpers;
+
+namespace aweXpect.Mocks.Tests.Setup;
+
+public class MethodWithReturnValueSetupTests
+{
+	public sealed class WithoutParametersTests
+	{
+		[Theory]
+		[InlineData("FooMethod", true)]
+		[InlineData("BarMethod", false)]
+		public async Task Callback_ForMatchingMethod_ShouldBeExecuted(string calledMethod, bool expectedResult)
+		{
+			var mock = new MyMock<int>(3);
+			bool isCalled = false;
+			var sut = new MethodWithReturnValueSetup<int>("FooMethod");
+			sut.Callback(() => { isCalled = true; });
+			mock.Registration.RegisterMethod(sut);
+
+			mock.Registration.Execute<int>(calledMethod);
+
+			await That(isCalled).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
+		[InlineData("FooMethod", 42)]
+		[InlineData("BarMethod", 0)]
+		public async Task Returns_ForMatchingMethod_ShouldReturnExpectedValue(string calledMethod, int expectedValue)
+		{
+			var mock = new MyMock<int>(3);
+			var sut = new MethodWithReturnValueSetup<int>("FooMethod");
+			sut.Returns(42);
+			mock.Registration.RegisterMethod(sut);
+
+			int result = mock.Registration.Execute<int>(calledMethod);
+
+			await That(result).IsEqualTo(expectedValue);
+		}
+
+		[Theory]
+		[InlineData("FooMethod", 42)]
+		[InlineData("BarMethod", 0)]
+		public async Task Returns_WithCallback_ForMatchingMethod_ShouldReturnExpectedValue(string calledMethod, int expectedValue)
+		{
+			var mock = new MyMock<int>(3);
+			var sut = new MethodWithReturnValueSetup<int>("FooMethod");
+			sut.Returns(() => 42);
+			mock.Registration.RegisterMethod(sut);
+
+			int result = mock.Registration.Execute<int>(calledMethod);
+
+			await That(result).IsEqualTo(expectedValue);
+		}
+	}
+	public sealed class With1ParameterTests
+	{
+		[Theory]
+		[InlineData("FooMethod", true)]
+		[InlineData("BarMethod", false)]
+		public async Task Callback_ForMatchingMethod_ShouldBeExecuted(string calledMethod, bool expectedResult)
+		{
+			var mock = new MyMock<int>(3);
+			bool isCalled = false;
+			var sut = new MethodWithReturnValueSetup<int, string>("FooMethod", With.Any<string>());
+			sut.Callback(() => { isCalled = true; });
+			mock.Registration.RegisterMethod(sut);
+
+			mock.Registration.Execute<int>(calledMethod, "bar");
+
+			await That(isCalled).IsEqualTo(expectedResult);
+		}
+
+		[Theory]
+		[InlineData("FooMethod", 42)]
+		[InlineData("BarMethod", 0)]
+		public async Task Returns_ForMatchingMethod_ShouldReturnExpectedValue(string calledMethod, int expectedValue)
+		{
+			var mock = new MyMock<int>(3);
+			var sut = new MethodWithReturnValueSetup<int, string>("FooMethod", With.Any<string>());
+			sut.Returns(42);
+			mock.Registration.RegisterMethod(sut);
+
+			int result = mock.Registration.Execute<int>(calledMethod, "bar");
+
+			await That(result).IsEqualTo(expectedValue);
+		}
+
+		[Theory]
+		[InlineData("FooMethod", 42)]
+		[InlineData("BarMethod", 0)]
+		public async Task Returns_WithCallback_ForMatchingMethod_ShouldReturnExpectedValue(string calledMethod, int expectedValue)
+		{
+			var mock = new MyMock<int>(3);
+			var sut = new MethodWithReturnValueSetup<int, string>("FooMethod", With.Any<string>());
+			sut.Returns(() => 42);
+			mock.Registration.RegisterMethod(sut);
+
+			int result = mock.Registration.Execute<int>(calledMethod, "bar");
+
+			await That(result).IsEqualTo(expectedValue);
+		}
+
+		[Fact]
+		public async Task Returns_WithCallback_ShouldReceiveParameter()
+		{
+			string receivedParameter = string.Empty;
+			var mock = new MyMock<int>(3);
+			var sut = new MethodWithReturnValueSetup<int, string>("FooMethod", With.Any<string>());
+			sut.Returns(p => {
+				receivedParameter = p;
+				return 42;
+			});
+			mock.Registration.RegisterMethod(sut);
+
+			int result = mock.Registration.Execute<int>("FooMethod", "bar");
+
+			await That(result).IsEqualTo(42);
+			await That(receivedParameter).IsEqualTo("bar");
+		}
+	}
+}

--- a/Tests/aweXpect.Mocks.Tests/TestHelpers/MyMock.cs
+++ b/Tests/aweXpect.Mocks.Tests/TestHelpers/MyMock.cs
@@ -1,0 +1,9 @@
+﻿using aweXpect.Mocks.Setup;
+
+namespace aweXpect.Mocks.Tests.TestHelpers;
+
+public class MyMock<T>(T @object) : Mock<T>(MockBehavior.Default)
+{
+	public IMockSetup Registration => Setup;
+	public override T Object => @object;
+}


### PR DESCRIPTION
The PR implements behavior-based return value handling for mocking methods by updating the return value generation to use the configured MockBehavior instead of throwing exceptions when no setup is provided.

### Key changes:
- Updates method setup classes to use MockBehavior for default return values instead of throwing a `NotSupportedException`
- Refactors the MyMock test helper class into a shared TestHelpers namespace
- Updates API documentation and XML comments to reflect the new behavior parameter